### PR TITLE
To make it clearer that there are 3 scripts to include

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ Based on the [vr-mode-ui](https://github.com/aframevr/aframe/blob/v0.7.0/src/com
 ## Usage
 
 ### Browser
-Include three.xr.js &amp; aframe-xr after A-frame (For now, we are using master version. Soon an official published version):
+Include A-Frame (for now, we are using master version - soon an official published version), followed by `three.xr.js` &amp; `aframe-xr`:
 ```html
-<script src="../../../vendor/aframe-master.js"></script>
+<script src="aframe-master.js"></script>
+<script src="three.xr.js"></script>
 <script src='aframe-xr.js'></script>
 ```
 

--- a/examples/xr/basic/index.html
+++ b/examples/xr/basic/index.html
@@ -4,7 +4,8 @@
     <title>Hello, WebVR! - A-Frame</title>
     <meta name="description" content="Hello, WebXR! - A-Frame">
     <!-- Origin Trial Token, feature = WebVR (For Chrome M62+), origin = https://webxrexperiments.com, expires = 2018-05-01 -->
-    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M62+)" data-expires="2018-05-01" content="ArKeZe0EK5eAEXO1K+Uj07h/yA2ylN8xwt+12LVV8ReELbePVTiSBRd4GYOnKzHpFktLh/nkPafQFDuvMhVX4goAAABseyJvcmlnaW4iOiJodHRwczovL3dlYnhyZXhwZXJpbWVudHMuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJWUjEuMU02MiIsImV4cGlyeSI6MTUyNTE3ODYwNywiaXNTdWJkb21haW4iOnRydWV9">    <script src='../../../vendor/aframe-master.js'></script>
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M62+)" data-expires="2018-05-01" content="ArKeZe0EK5eAEXO1K+Uj07h/yA2ylN8xwt+12LVV8ReELbePVTiSBRd4GYOnKzHpFktLh/nkPafQFDuvMhVX4goAAABseyJvcmlnaW4iOiJodHRwczovL3dlYnhyZXhwZXJpbWVudHMuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJWUjEuMU02MiIsImV4cGlyeSI6MTUyNTE3ODYwNywiaXNTdWJkb21haW4iOnRydWV9">
+    <script src='../../../vendor/aframe-master.js'></script>
     <script src='../../../vendor/three.xr.js'></script>
     <script src='../../../dist/aframe-xr.js'></script>
   </head>


### PR DESCRIPTION
Hi. The README currently says: `Include three.xr.js & aframe-xr after A-frame...`. But the code example currently looks like this:

```
<script src="../../../vendor/aframe-master.js"></script>
<script src='aframe-xr.js'></script>
```

So I thought I just needed to include `aframe-master.js` and `aframe-xr.js`.

Also, taking a look at the [xr-basic example](https://github.com/mozilla/aframe-xr/blob/master/examples/xr/basic/index.html) caused me some temporary further confusion, because the `aframe-master.js` script tag is off-screen, over the right-hand side, after the origin trial tag.

So this PR is my recommendation for extra newbie-friendliness:
* `README.md`: add `three.xr.js` script include
* `README.md`: remove `../../../vendor/` path, to make the 3 includes consistent and more general
* `xr/basic/index.html`: move the script tag onto its own line

WDYT? :)