### PR TITLE
Avoid creating objects in reticle and xranchor components

### DIFF
--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -7,7 +7,6 @@ AFRAME.registerComponent('xranchor', {
     this.anchorMatrix = new THREE.Matrix4();
     this.positionVec3 = new THREE.Vector3();
     this.rotationQuat = new THREE.Quaternion();
-    this.rotationVec3 = new THREE.Vector3();
     this.el.sceneEl.addEventListener(
       'updateFrame',
       this.updateFrame.bind(this)
@@ -29,20 +28,9 @@ AFRAME.registerComponent('xranchor', {
       anchorOffset.getOffsetTransform(anchor.coordinateSystem)
     );
     var positionVec3 = this.positionVec3.setFromMatrixPosition(anchorMatrix);
-
-    this.el.setAttribute('position', {
-      x: positionVec3.x,
-      y: positionVec3.y,
-      z: positionVec3.z
-    });
+    this.el.object3D.position.copy(positionVec3);
 
     var rotationQuat = this.rotationQuat.setFromRotationMatrix(anchorMatrix);
-    var rotationVec3 = this.rotationVec3.applyQuaternion(rotationQuat);
-
-    this.el.setAttribute('rotation', {
-      x: rotationVec3.x,
-      y: rotationVec3.y,
-      z: rotationVec3.z
-    });
+    this.el.object3D.quaternion.copy(rotationQuat);
   }
 });

--- a/src/components/reticle.js
+++ b/src/components/reticle.js
@@ -15,6 +15,10 @@ AFRAME.registerComponent('reticle', {
 
     this.tapData = [0.5, 0.5];
     this.onTouchStart = this.onTouchStart.bind(this);
+    this.model = new THREE.Matrix4();
+    this.tempPos = new THREE.Vector3();
+    this.tempQuat = new THREE.Quaternion();
+    this.tempScale = new THREE.Vector3();
   },
   onTouchStart: function (ev) {
     if (!ev.touches || ev.touches.length === 0) {
@@ -31,25 +35,17 @@ AFRAME.registerComponent('reticle', {
   updateFrame: function (data) {
     var frame = data.detail;
     var hit = frame.hitTestNoAnchor(this.tapData[0], this.tapData[1]);
-    var model = new THREE.Matrix4();
-    var tempPos = new THREE.Vector3();
-    var tempQuat = new THREE.Quaternion();
-    var tempScale = new THREE.Vector3();
     if (hit && hit.length > 0) {
       if (this.el.getAttribute('visible') === false) {
         this.el.setAttribute('visible', true);
         this.el.emit('planeDetected');
         window.addEventListener('touchstart', this.onTouchStart);
       }
-      model.fromArray(hit[0].modelMatrix);
-      model.decompose(tempPos, tempQuat, tempScale); 
-      this.el.setAttribute('position', {
-        x: tempPos.x,
-        y: tempPos.y,
-        z: tempPos.z
-      })
-      tempQuat.multiply(this.extraRotation)
-      this.el.object3D.quaternion.copy(tempQuat);
+      this.model.fromArray(hit[0].modelMatrix);
+      this.model.decompose(this.tempPos, this.tempQuat, this.tempScale);
+      this.el.object3D.position.copy(this.tempPos);
+      this.tempQuat.multiply(this.extraRotation)
+      this.el.object3D.quaternion.copy(this.tempQuat);
     }
   }
 });


### PR DESCRIPTION
I optimized the reticle and xranchor components to not create objects on each frame.
I tested the reticle component. I did not test xranchor component, so be sure to test it before merge.